### PR TITLE
Add liquid benchmarks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "optcarrot_benchmarks/optcarrot"]
 	path = optcarrot_benchmarks/optcarrot
 	url = https://github.com/mame/optcarrot.git
+[submodule "liquid_benchmarks/liquid"]
+	path = liquid_benchmarks/liquid
+	url = https://github.com/Shopify/liquid.git

--- a/liquid_benchmarks/benchmark_liquid.rb
+++ b/liquid_benchmarks/benchmark_liquid.rb
@@ -1,0 +1,46 @@
+require 'benchmark/ips'
+require 'json'
+
+module Benchmark
+  module Liquid
+    def liquid(label=nil, time: 10, warmup: 5, &block)
+      unless block_given?
+        raise ArgumentError.new, "block should be passed"
+      end
+
+      report = Benchmark.ips(time, warmup, true) do |x|
+        x.report(label) { yield }
+      end
+
+      entry = report.entries.first
+
+      output = {
+        label: label,
+        version: ::Liquid::VERSION.to_s,
+        iterations_per_second: entry.ips,
+        iterations_per_second_standard_deviation: entry.ips_sd,
+        total_allocated_objects_per_iteration: get_total_allocated_objects(&block)
+      }.to_json
+
+      puts output
+    end
+
+    def get_total_allocated_objects
+      if block_given?
+        key =
+          if RUBY_VERSION < '2.2'
+            :total_allocated_object
+          else
+            :total_allocated_objects
+          end
+
+        before = GC.stat[key]
+        yield
+        after = GC.stat[key]
+        after - before
+      end
+    end
+  end
+
+  extend Benchmark::Liquid
+end

--- a/liquid_benchmarks/bm_parse.rb
+++ b/liquid_benchmarks/bm_parse.rb
@@ -1,0 +1,8 @@
+require_relative 'benchmark_liquid'
+require_relative 'liquid/performance/theme_runner'
+
+profiler = ThemeRunner.new
+
+Benchmark.liquid("parse") do
+  profiler.compile
+end

--- a/liquid_benchmarks/bm_parse_and_render.rb
+++ b/liquid_benchmarks/bm_parse_and_render.rb
@@ -1,0 +1,8 @@
+require_relative 'benchmark_liquid'
+require_relative 'liquid/performance/theme_runner'
+
+profiler = ThemeRunner.new
+
+Benchmark.liquid("parse_and_render") do
+  profiler.run
+end

--- a/liquid_benchmarks/bm_render.rb
+++ b/liquid_benchmarks/bm_render.rb
@@ -1,0 +1,8 @@
+require_relative 'benchmark_liquid'
+require_relative 'liquid/performance/theme_runner'
+
+profiler = ThemeRunner.new
+
+Benchmark.liquid("render") do
+  profiler.render
+end

--- a/liquid_benchmarks/driver.rb
+++ b/liquid_benchmarks/driver.rb
@@ -1,0 +1,142 @@
+#
+# Liquid Benchmark driver
+#
+require 'digest'
+require 'net/http'
+require 'json'
+require 'pathname'
+require 'optparse'
+
+RAW_URL = 'https://raw.githubusercontent.com/ruby-bench/ruby-bench-suite/master/liquid/benchmarks/'
+
+class BenchmarkDriver
+  def self.benchmark(options)
+    self.new(options).run
+  end
+
+  def initialize(options)
+    @repeat_count = options[:repeat_count]
+    @pattern = options[:pattern]
+    @local = options[:local]
+  end
+
+  def run
+    files.each do |path|
+      next if !@pattern.empty? && /#{@pattern.join('|')}/ !~ File.basename(path)
+      run_single(path)
+    end
+  end
+
+  private
+
+  def files
+    Pathname.glob("#{File.expand_path(File.dirname(__FILE__))}/bm_*")
+  end
+
+  def run_single(path)
+    script = "ruby #{path}"
+
+    output = measure(script)
+    return unless output
+
+    request = Net::HTTP::Post.new('/benchmark_runs')
+    request.basic_auth(ENV["API_NAME"], ENV["API_PASSWORD"])
+
+    initiator_hash = {}
+    if(ENV['RUBY_COMMIT_HASH'])
+      initiator_hash['commit_hash'] = ENV['RUBY_COMMIT_HASH']
+    elsif(ENV['RUBY_VERSION'])
+      initiator_hash['version'] = ENV['RUBY_VERSION']
+    end
+
+    submit = {
+      'benchmark_type[category]' => "Liquid #{output['label']}",
+      'benchmark_type[script_url]' => "#{RAW_URL}#{path.basename}",
+      'benchmark_type[digest]' => generate_digest(path),
+      'benchmark_run[environment]' => "#{`ruby -v; gem -v`.strip}",
+      'repo' => 'ruby',
+      'organization' => 'ruby'
+    }.merge(initiator_hash)
+
+    request.set_form_data(submit.merge(
+      {
+        "benchmark_run[result][iterations_per_second]" => output["iterations_per_second"].round(3),
+        'benchmark_result_type[name]' => 'Number of iterations per second',
+        'benchmark_result_type[unit]' => 'Iterations per second'
+      }
+    ))
+
+    endpoint.request(request) unless @local
+
+    request.set_form_data(submit.merge(
+      {
+        "benchmark_run[result][total_allocated_objects_per_iteration]" => output["total_allocated_objects_per_iteration"],
+        'benchmark_result_type[name]' => 'Allocated objects',
+        'benchmark_result_type[unit]' => 'Objects'
+      }
+    ))
+
+    if @local
+      puts output
+    else
+      endpoint.request(request)
+      puts "Posting results to Web UI...."
+    end
+  end
+
+  def generate_digest(path)
+    Digest::SHA2.hexdigest("#{File.read(path)}#{`ruby -v; gem -v`}")
+  end
+
+  def endpoint
+    @endpoint ||= begin
+      http = Net::HTTP.new(ENV["API_URL"] || 'rubybench.org', 443)
+      http.use_ssl = true
+      http
+    end
+  end
+
+  def measure(script)
+    begin
+      results = []
+
+      @repeat_count.times do
+        result = JSON.parse(`#{script}`)
+        puts "#{result["label"]} #{result["iterations_per_second"]}/ips"
+        results << result
+      end
+
+      results.sort_by do |result|
+        result['iterations_per_second']
+      end.last
+    rescue JSON::ParserError
+      # Do nothing
+    end
+  end
+
+
+end
+
+options = {
+  repeat_count: 1,
+  pattern: [],
+  local: false,
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ruby driver.rb [options]"
+
+  opts.on("-r", "--repeat-count [NUM]", "Run benchmarks [NUM] times taking the best result") do |value|
+    options[:repeat_count] = value.to_i
+  end
+
+  opts.on("-p", "--pattern <PATTERN1,PATTERN2,PATTERN3>", "Benchmark name pattern") do |value|
+    options[:pattern] = value.split(',')
+  end
+
+  opts.on("--local", "Don't report benchmark results to the server") do |value|
+    options[:local] = value
+  end
+end.parse!(ARGV)
+
+BenchmarkDriver.benchmark(options)


### PR DESCRIPTION
The `bm_*` files call the benchmarking functions in https://github.com/Shopify/liquid/blob/master/performance/theme_runner.rb (`run` and `compile` for now, and `render` once https://github.com/Shopify/liquid/pull/851 is in).

Including liquid as a submodule to access its `performance/` directory which has the test liquid files and other useful things.

TODO:
- [x] update liquid submodule commit